### PR TITLE
Fix namespace resolution

### DIFF
--- a/phalcon/mvc/router/annotations.zep
+++ b/phalcon/mvc/router/annotations.zep
@@ -147,7 +147,7 @@ class Annotations extends Router
 			 */
 			fetch moduleName, scope[2];
 
-			let sufixed = handler . controllerSuffix;
+			let sufixed = controllerName . controllerSuffix;
 
 			/**
 			 * Add namespace to class if one is set


### PR DESCRIPTION
Fixed an issue that caused the fully qualified class to have the namespace duplicated in sufixed when handle contains a namespace itself.
